### PR TITLE
Add support for JSON formatting  /  Always use `stderr` for error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "panic_analysis 0.1.0",
  "serde 1.0.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_common 0.1.0",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.4.6"
 serde = "1.0.64"
 serde_derive = "1.0.64"
 error-chain = "0.11.0"
+serde_json = "1.0.22"
 
 [dev-dependencies]
 assert_cli = "0.5"

--- a/src/cmd_args.rs
+++ b/src/cmd_args.rs
@@ -69,6 +69,7 @@ pub fn get_args() -> Result<(AnalysisOptions, OutputOptions)> {
     let output_options = OutputOptions {
         verbose: cmd_matches.is_present("verbose"),
         silent: cmd_matches.is_present("silent"),
+        json: cmd_matches.is_present("json"),
     };
 
     Ok((rdp_options, output_options))
@@ -107,6 +108,13 @@ fn get_app_definition<'a, 'b>() -> App<'a, 'b> {
                 .help("Turn on verbose mode for full stack traces of panic calls"),
         )
         .arg(
+            Arg::with_name("json")
+                .short("j")
+                .long("json")
+                .conflicts_with("silent")
+                .help("Output full stack traces of panic calls into JSON"),
+        )
+        .arg(
             Arg::with_name("config")
                 .long("config")
                 .help("Path to RDP configuration file (default: rdp.toml)")
@@ -123,6 +131,7 @@ fn get_app_definition<'a, 'b>() -> App<'a, 'b> {
                 .short("s")
                 .long("silent")
                 .conflicts_with("verbose")
+                .conflicts_with("json")
                 .help("Turn on silent mode to not print anything"),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,17 @@
 //! obtained by running `rustig --help` on a build or by visiting the 
 //! [Github documentation](https://github.com/Technolution/rustig).
 //! 
+
+#![recursion_limit="128"]
+
 #[macro_use]
 extern crate serde_derive;
 extern crate panic_analysis;
 extern crate toml;
 #[macro_use]
 extern crate error_chain;
+#[macro_use]
+extern crate serde_json;
 
 mod cmd_args;
 mod config_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ pub fn main() {
     // Parse cmd arguments
     let (cmd_args, output_options) = match cmd_args::get_args() {
         Err(e) => {
-            println!("{}", e);
+            eprintln!("{}", e);
             process::exit(101);
         }
         Ok(r) => r,
@@ -51,7 +51,7 @@ pub fn main() {
     // Execute analysis
     match panic_analysis::find_panics(&cmd_args) {
         Err(e) => {
-            println!("{}", e);
+            eprintln!("{}", e);
             process::exit(101);
         }
         Ok(collection) => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -60,6 +60,7 @@ use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::ops::Deref;
+use std::io::Write;
 
 /// Set of options on how to format the output.
 pub struct OutputOptions {
@@ -195,7 +196,12 @@ impl OutputStream for JsonConsoleOutputStream {
                         }).collect()
                 ),
             });
-            json::to_writer_pretty (stream.lock(), &json).unwrap();
+            {
+                let mut stream = stream.lock();
+                write!(&mut stream, "\n\n").unwrap();
+                json::to_writer_pretty (&mut stream, &json).unwrap();
+                write!(&mut stream, "\n\n").unwrap();
+            }
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -67,6 +67,8 @@ pub struct OutputOptions {
     pub silent: bool,
     /// The verbose flag for command line output.
     pub verbose: bool,
+    /// The JSON flag for command line output.
+    pub json: bool,
 }
 
 /// A struct consisting of a vector containing the output streams
@@ -205,7 +207,9 @@ fn get_output_streams(options: &OutputOptions) -> Box<OutputStreamsCollection> {
         return Box::new(OutputStreamsCollection { streams: vec![] });
     }
 
-    if options.verbose {
+    if options.json {
+        output_stream_vec.push(Box::new(JsonConsoleOutputStream {}));
+    } else if options.verbose {
         output_stream_vec.push(Box::new(VerboseConsoleOutputStream {}));
     } else {
         output_stream_vec.push(Box::new(SimpleConsoleOutputStream {}));

--- a/src/output.rs
+++ b/src/output.rs
@@ -44,11 +44,22 @@
 //!  3: rust_begin_unwind (stdlib@1.26.2)
 //!          at /checkout/src/libstd/panicking.rs:325
 //!  4: std::panicking::begin_panic_fmt (stdlib@1.26.2)
+//!
+//! ### 3. JSON.
+//! The same amount of information as verbose, but formatted as JSON.
 //! ```
 extern crate callgraph;
 extern crate panic_analysis;
+extern crate serde_json;
 
 use panic_analysis::PanicCallsCollection;
+use panic_analysis::PanicPattern;
+use serde_json as json;
+use std::io;
+use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::ops::Deref;
 
 /// Set of options on how to format the output.
 pub struct OutputOptions {
@@ -97,6 +108,92 @@ impl OutputStream for VerboseConsoleOutputStream {
                 trace,
                 width = (panic_calls.calls.len() as f64).log10().ceil() as usize,
             )
+        }
+    }
+}
+
+/// Struct that handles JSON console output formatting
+#[derive(Debug, Clone)]
+struct JsonConsoleOutputStream {}
+
+impl OutputStream for JsonConsoleOutputStream {
+    fn print_output(&self, panic_calls: &PanicCallsCollection) {
+        let stream = io::stdout();
+        for (i, trace) in panic_calls.calls.iter().enumerate() {
+            let json = json!({
+                "index" : i,
+                "pattern" : match trace.pattern.borrow().deref() {
+                    PanicPattern::Unrecognized => "unrecognized",
+                    PanicPattern::DirectCall => "direct_call",
+                    PanicPattern::Unwrap => "unwrap",
+                    PanicPattern::Indexing => "indexing",
+                    PanicPattern::Arithmetic => "arithmetic",
+                },
+                "message" : if let Some(message) = &trace.message { message.clone().into() } else { json::Value::Null },
+                "dynamic_invocation" : trace.contains_dynamic_invocation,
+                "backtrace" : json::Value::Array(
+                    trace.backtrace.iter().enumerate().map(|(i, backtrace)| {
+                            let backtrace = backtrace.borrow();
+                            let procedure = backtrace.procedure.deref().borrow();
+                            let invocation = backtrace.outgoing_invocation.as_ref().map(Rc::deref).map(RefCell::borrow);
+                            json!({
+                                "index" : i,
+                                "procedure" : json!({
+                                    "name" : procedure.name.clone(),
+                                    "linkage_name" : procedure.linkage_name.clone(),
+                                    "linkage_name_demangled" : procedure.linkage_name_demangled.clone(),
+                                    "crate" : json!({
+                                        "name" : procedure.defining_crate.name.clone(),
+                                        "version" : if let Some(ref version) = &procedure.defining_crate.version { version.clone().into() } else { json::Value::Null },
+                                    }),
+                                    "location" : if let Some(ref location) = &procedure.location {
+                                            json!({
+                                                "file" : location.file.clone(),
+                                                "line" : location.line,
+                                            })
+                                        } else {
+                                            json::Value::Null
+                                        },
+                                    "is_entry" : procedure.attributes.entry_point,
+                                    "is_reachable" : procedure.attributes.reachable_from_entry_point,
+                                    "is_panic" : procedure.attributes.is_panic,
+                                    "is_panic_origin" : procedure.attributes.is_panic_origin,
+                                    "is_whitelisted" : procedure.attributes.whitelisted,
+                                }),
+                                "invocation" :
+                                    if let Some(invocation) = invocation {
+                                        json!({
+                                            "type" : match invocation.invocation_type {
+                                                callgraph::InvocationType::Direct => "direct",
+                                                callgraph::InvocationType::ProcedureReference => "procedure",
+                                                callgraph::InvocationType::VTable => "vtable",
+                                                callgraph::InvocationType::Jump => "jump",
+                                            },
+                                            "is_whitelisted" : invocation.attributes.whitelisted,
+                                            "frames" : json::Value::Array(
+                                                invocation.frames.iter().enumerate().map(|(i, frame)| {
+                                                    json!({
+                                                        "index" : i,
+                                                        "function" : frame.function_name.clone(),
+                                                        "location" : json!({
+                                                            "file" : frame.location.file.clone(),
+                                                            "line" : frame.location.line,
+                                                        }),
+                                                        "crate" : json!({
+                                                            "name" : frame.defining_crate.name.clone(),
+                                                            "version" : if let Some(ref version) = &frame.defining_crate.version { version.clone().into() } else { json::Value::Null },
+                                                        }),
+                                                    })
+                                                }).collect()),
+                                        })
+                                    } else {
+                                        json::Value::Null
+                                    },
+                            })
+                        }).collect()
+                ),
+            });
+            json::to_writer_pretty (stream.lock(), &json).unwrap();
         }
     }
 }


### PR DESCRIPTION
The first small patch replaces `println!` with `eprintln!` in `main` so that errors are printed to `stderr`, and thus allowing one to better integrate `rustig` into other pipelines.

The other four patches add support for JSON formatting of the analysis.
The format used is in fact a "JSON-stream" (i.e. one object after another separated by empty lines), which are perfect for consumption by the `jq` tool.

For example if one dumps the contents of the analysis of `rustig` itself into a JSON file, then one can execute the following `jq` query that prints all the "top" functions that might cause a panic, but whose "pattern" is not trivial (like unwrap, indexing, or airthmetic):
````
./target/release/rustig --json --binary ./target/debug/rustig > /tmp/rustig.json
````

````
jq --slurp '
    map(select(.pattern != "unwrap" and .pattern != "arithmetic" and .pattern != "indexing"))
    | map([.pattern, .backtrace[0].procedure.linkage_name_demangled])
    | unique
    | .[]
' < /tmp/rustig.json
````
